### PR TITLE
fix(buildspec): Multi-region

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,10 +3,7 @@ version: 0.2
 env:
     variables:
         AWS_ACCOUNT_ID: '239844027862'
-        AWS_DEFAULT_REGION: us-east-1
         IMAGE_REPO_NAME: adazza-ci-ecr
-    # parameter-store:
-    #   LOGIN_PASSWORD: "dockerLoginPassword"
 
 phases:
     install:


### PR DESCRIPTION
CodeBuild already sets `AWS_DEFAULT_REGION` (https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html), so to make this build on multiple regions we simply remove this manually set env var.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adazza/adazza-ci-docker/2)
<!-- Reviewable:end -->
