### PR TITLE
feat(frontend-web): Assert node/npm/yarn versions

### DIFF
--- a/images/frontend-web/Dockerfile
+++ b/images/frontend-web/Dockerfile
@@ -9,7 +9,9 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update
 RUN apt-get install -y nodejs firefox google-chrome-stable google-chrome-unstable awscli
-RUN npm i -g npm yarn
+RUN npm i -g npm yarn check-node-version
+
+RUN check-node-version --node ^10.11.0 --yarn ^1.9.4 --npm ^6.4.1
 
 RUN mkdir /project
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
- This also allows us to bump the version of
  node/npm/yarn in the image by updating the assertion