### PR TITLE
fix(buildspec): Use phases correctly

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,7 +9,7 @@ phases:
     install:
         commands:
             - echo Installing node dependencies
-            - yarn install --frozen-lockfile
+            - yarn install --frozen-lockfile --prefer-offline
             # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html
             - echo Starting docker daemon
             - nohup dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay&
@@ -19,15 +19,13 @@ phases:
             - echo Logging in to Amazon ECR
             - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
             - echo Caching existing layers
-            - yarn run pre_build
+            - yarn run pull
     build:
         commands:
             - echo Building the Docker images
             - yarn run build
-    post_build:
-        commands:
-            - echo Pushing the Docker images
-            - yarn run post_build
+            - yarn run tag
+            - yarn run push
 
 cache:
     paths:

--- a/images/frontend-web/Dockerfile
+++ b/images/frontend-web/Dockerfile
@@ -9,9 +9,9 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update
 RUN apt-get install -y nodejs firefox google-chrome-stable google-chrome-unstable awscli
-RUN npm i -g npm yarn check-node-version
+RUN npm i -g npm@'~6.4.1' yarn@'~1.9.4' n
 
-RUN check-node-version --node ^10.11.0 --yarn ^1.9.4 --npm ^6.4.1
+RUN n 10.11.0
 
 RUN mkdir /project
 ENTRYPOINT ["bash"]

--- a/package.json
+++ b/package.json
@@ -8,11 +8,10 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "pre_build": "lerna exec -- docker pull \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME || echo 'New image'",
-    "build": "run-s build:build build:tag",
-    "build:build": "lerna exec -- docker build --cache-from \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME -t \\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME .",
-    "build:tag": "lerna exec -- docker tag \\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME",
-    "post_build": "lerna exec -- docker push \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME"
+    "build": "lerna exec -- docker build --cache-from \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME -t \\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME .",
+    "pull": "lerna exec -- docker pull \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME || echo 'New image'",
+    "push": "lerna exec -- docker push \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME",
+    "tag": "lerna exec -- docker tag \\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME \\$AWS_ACCOUNT_ID.dkr.ecr.\\$AWS_DEFAULT_REGION.amazonaws.com/\\$IMAGE_REPO_NAME:\\$LERNA_PACKAGE_NAME"
   },
   "devDependencies": {
     "lerna": "3.3.0",


### PR DESCRIPTION
Overview
--------

POST_BUILD phase was being used incorrectly (see links below).  Node cache busting change is somewhat unrelated, but needed to get the build working correctly again.

- https://docs.aws.amazon.com/codebuild/latest/userguide/view-build-details.html#view-build-details-phases
- https://stackoverflow.com/questions/46584324/code-build-continues-after-build-fails

Changes
-------

- Remove post_build phase, move all to build
- Rename yarn run scripts
- Fix frontend-web node caching issue
    - Related to #8

Testing
----------

1. `docker build -t local-frontend-web images/frontend-web/`
1. `docker run -i -t --entrypoint bash local-frontend-web`
1. Within the container, you can test that `n` is working
1. `node -v`
    - should be `v10.11.0`
1. `n 8.12`
1. `node -v`
    - should be `v8.12.0`
