### PR TITLE
Install ansible on the finatra hosts.

### DIFF
--- a/images/finatra-postgres/Dockerfile
+++ b/images/finatra-postgres/Dockerfile
@@ -16,6 +16,10 @@ RUN apt-get install -y apt-transport-https ca-certificates curl software-propert
 RUN apt-get install -y openjdk-8-jdk
 RUN apt-get install -y postgresql-9.6 postgresql-contrib-9.6
 RUN apt-get install -y unzip
+RUN apt-get install -y python-pip
+RUN pip install ansible==2.6.3
+RUN pip install boto3 boto botocore
+RUN pip install dnspython
 
 RUN wget --quiet https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_amd64.zip -O /tmp/packer.zip
 RUN unzip /tmp/packer.zip -d /usr/local/bin/

--- a/images/finatra/Dockerfile
+++ b/images/finatra/Dockerfile
@@ -14,6 +14,10 @@ RUN wget --quiet https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_
 RUN unzip /tmp/packer.zip -d /usr/local/bin/
 RUN chmod '0755' /usr/local/bin/packer
 RUN rm /tmp/packer.zip
+RUN apt-get install -y python-pip
+RUN pip install ansible==2.6.3
+RUN pip install boto3 boto botocore
+RUN pip install dnspython
 
 RUN mkdir /project
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
We need ansible to do the packer AMI creation. As we extend this into a
full pipeline this will be taken out and moved into a distinct bakery
AMI.


Overview
--------

Brief summary

- install ansible on both finatra images.

Testing
-------

1. run docker build for each image.