### PR TITLE
Add postgres 9.6 image with default port exposed.

### DIFF
--- a/images/local-postgres/Dockerfile
+++ b/images/local-postgres/Dockerfile
@@ -1,0 +1,31 @@
+FROM buildpack-deps:bionic
+
+ENV CI True
+
+# Docker prereq
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update
+
+# Postgres repo
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc  | apt-key add -
+
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates curl software-properties-common awscli
+RUN apt-get install -y postgresql-9.6 postgresql-contrib-9.6
+
+RUN update-rc.d postgresql enable
+
+USER postgres
+RUN service postgresql start && psql --command "CREATE USER adazza_test_user WITH SUPERUSER PASSWORD 'adazza_test_user';"
+RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.6/main/pg_hba.conf
+RUN echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
+
+USER root
+
+EXPOSE 5432
+
+RUN mkdir /project
+ENTRYPOINT ["bash"]
+WORKDIR /project

--- a/images/local-postgres/package.json
+++ b/images/local-postgres/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "local-postgres",
+  "version": "0.0.0",
+  "description": "",
+  "main": "Dockerfile",
+  "scripts": {
+    "lint": "dockerlint -p Dockerfile"
+  },
+  "author": "ben@adazza.com",
+  "license": "MIT",
+  "private": true
+}


### PR DESCRIPTION
Overview
--------

Adds new image with posgres 9.6 installed, the adazza test user created
and default port exposed.

Testing
-------

1. docker build -t local-post-test images/local-postgres