### PR TITLE
Add image to run finatra services.

### DIFF
--- a/images/finatra-runtime/Dockerfile
+++ b/images/finatra-runtime/Dockerfile
@@ -1,0 +1,18 @@
+FROM buildpack-deps:bionic
+
+# Docker prereq
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+RUN apt-get install -y openjdk-8-jdk
+RUN apt-get install -y python-pip
+RUN pip install boto3 boto botocore awscli
+RUN pip install dnspython
+
+RUN mkdir -p /opt/adazza/bin/
+RUN mkdir -p /opt/adazza/lib/
+COPY files/start-adazza-service /opt/adazza/bin/start-adazza-service
+RUN chmod +x /opt/adazza/bin/start-adazza-service
+
+WORKDIR /opt/adazza/

--- a/images/finatra-runtime/files/start-adazza-service
+++ b/images/finatra-runtime/files/start-adazza-service
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+_BASE_URL='http://169.254.169.254/latest'
+AWS_REGION=$(curl -s ${_BASE_URL}/dynamic/instance-identity/document | jq .region -r)
+INSTANCE_ID=$(curl -s ${_BASE_URL}/meta-data/instance-id)
+MAC=$(curl -s ${_BASE_URL}/meta-data/mac)
+IP=$(curl -s ${_BASE_URL}/meta-data/local-ipv4)
+HOSTNAME=$(hostname)
+
+JSON=$(aws ec2 describe-instances \
+       --region ${AWS_REGION} \
+       --instance-ids ${INSTANCE_ID})
+TIER=$(echo ${JSON} | jq '.Reservations[0].Instances[0].Tags[] | select(.Key == "Tier").Value' -r)
+
+service_name=$1
+service_version=$2
+service_artifact=$3
+
+export AWS_DEFAULT_REGION=${AWS_REGION}
+export ADAZZA_TIER=${TIER}
+export ADAZZA_REGION=${AWS_REGION}
+export ADAZZA_SERVICE=${service_name}
+export ADAZZA_SERVICE_VERSION=${service_version}
+export ADAZZA_INSTANCE_ID=${INSTANCE_ID}
+export ADAZZA_IP=${IP}
+export ADAZZA_MAC=${MAC}
+export ADAZZA_HOSTNAME=${HOSTNAME}
+
+ulimit -n 32768
+ulimit -u 10240
+
+exec /opt/${service_artifact}/bin/${service_artifact} -adazza.region ${AWS_REGION} -adazza.tier ${TIER} \
+                                              -adazza.service.name ${service_name} \
+                                              -adazza.service.version ${service_version} \
+                                              -thrift.port ':9999' \
+                                              -http.port ':8888'
+                                              -thrift.name ${service_name}

--- a/images/finatra-runtime/package.json
+++ b/images/finatra-runtime/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "finatra-runtime",
+  "version": "0.0.0",
+  "description": "",
+  "main": "Dockerfile",
+  "scripts": {
+    "lint": "dockerlint -p Dockerfile"
+  },
+  "author": "Ben McNiel <ben@adazza.com>",
+  "license": "MIT",
+  "private": true
+}


### PR DESCRIPTION
Adds an image to run an installed finatra service.

- sets up the start-adazza-service script
- creates adazza directories
- installs openjdk8